### PR TITLE
DHCP CI Test: Remove the need of radvd.

### DIFF
--- a/packaging/Dockerfile.centos7-nmstate-dev
+++ b/packaging/Dockerfile.centos7-nmstate-dev
@@ -7,7 +7,6 @@ RUN yum -y install \
         python2-devel \
         python2-pip \
         python36-pip \
-        radvd \
         rpm-build \
     && yum clean all
 

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -32,7 +32,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    python3-pytest \
                    python3-pytest-cov \
                    python3-tox \
-                   radvd \
                    rpm-build \
                    \
                    # Below packages for pip (used by tox) to build


### PR DESCRIPTION
The dnsmasq can send out extra route via RA using `dhcp-rang`,
hence there is not need to depend on radvd any more.