### PR TITLE
Skip security leak check on automation/upload_test_artifacts.key

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,6 @@
+[allowlist]
+  description = "Global Allowlist"
+  paths = [
+    # This ssh key is deactivated
+    'automation/upload_test_artifacts.key',
+  ]


### PR DESCRIPTION
The `automation/upload_test_artifacts.key` is deactivated ssh key,
it is not a security leak.